### PR TITLE
更好的分布式数据同步系统

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -1,4 +1,3 @@
-import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
 import net.minecrell.pluginyml.paper.PaperPluginDescription
 
 plugins {
@@ -20,6 +19,7 @@ dependencies {
     implementation(project(":api"))
     implementation(project(":papi"))
     implementation(project(":mini"))
+    implementation(local.redisson)
     implementation(local.lang.bukkit)
     implementation(libs.cloud2.core)
     implementation(libs.cloud2.paper)

--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -17,6 +17,7 @@ helper-sql = "1.3.2"
 lang-bukkit = "1.3-SNAPSHOT"
 placeholderapi = "2.11.6"
 miniplaceholders = "2.2.3"
+redisson = "3.38.1"
 
 [libraries]
 
@@ -35,6 +36,7 @@ jedis = { group = "redis.clients", name = "jedis", version.ref = "jedis" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
+redisson = { group = "org.redisson", name = "redisson", version.ref = "redisson" }
 helper = { group = "me.lucko", name = "helper", version.ref = "helper" }
 helper-redis = { group = "me.lucko", name = "helper-redis", version.ref = "helper-redis" }
 helper-sql = { group = "me.lucko", name = "helper-sql", version.ref = "helper-sql" }


### PR DESCRIPTION
### 现状

目前的数据同步机制基于 Redis 的 PubSub.  

假如有 3 个 UUID 一样的 Account 实例分别存在于 3 个 JVM 上, 那么当其中一个 Account 的数据发生变化后, 将 (通过PubSub) 通知其他 JVM 上的 Account 重新从数据库拉取一次数据. 拉取的数据将覆盖 Account 原有的所有数据.

这样的设计有两个问题:
- 运行效率低
- 数据不一致

运行效率低是因为每次更新数据都会从数据库重新拉取, 而显然这一点可以通过 Redis 来实现更高的效率. 目前规模不大, 现有方案暂且够用, 但一旦更新频率上去后, 所带来的性能问题会越发明显.

至于数据不一致的问题, 目前的设计可以在大部分情况下保证数据一致, 但在一些可能发生的极端情况里, 依然会导致数据不一致的问题发生. 数据不一致一旦发生, 被某些玩家恶意利用的话后果不堪设想. 想象一下玩家可以无限刷硬币, 甚至是刷米币等等. 又或者是玩家在商店购买物品的时候, 同时有个在其他服务器的玩家给他转账.

### 解决方案

SQL 作为永久数据的储存方案, 而对于缓存了的 Account 实例, 应该始终直接从 Redis 读写数据.